### PR TITLE
Test improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ doc/
 pkg/
 coverage/
 *.log
+Gemfile.lock

--- a/lib/poseidon/consumer_group.rb
+++ b/lib/poseidon/consumer_group.rb
@@ -37,7 +37,9 @@ class Poseidon::ConsumerGroup
     def initialize(group, partition, options = {})
       broker = group.leader(partition)
       offset = group.offset(partition)
-      offset = (options[:trail] ? :latest_offset : :earliest_offset) if offset == 0
+      # if trail is set to true, it should always use latest offset. Otherwise use the zookeeper offset
+      # if there was one, or earliset available if there wasn't.
+      offset = (options[:trail] ? :latest_offset : (offset == 0 ? :earliest_offset : offset))
       options.delete(:trail)
       super group.id, broker.host, broker.port, group.topic, partition, offset, options
     end

--- a/lib/poseidon/consumer_group.rb
+++ b/lib/poseidon/consumer_group.rb
@@ -79,6 +79,9 @@ class Poseidon::ConsumerGroup
   # @attr_reader [Hash] options Consumer options
   attr_reader :options
 
+  # @attr_reader [Integer] loop delay extracted from options and exposed
+  attr_reader :loop_delay
+
   # Create a new consumer group, which processes all partition of the specified topic.
   #
   # @param [String] name Group name
@@ -97,6 +100,7 @@ class Poseidon::ConsumerGroup
   #
   # @api public
   def initialize(name, brokers, zookeepers, topic, options = {})
+    puts options.inspect
     @name       = name
     @topic      = topic
     @zk         = ::ZK.new(zookeepers.join(","))
@@ -110,6 +114,7 @@ class Poseidon::ConsumerGroup
     @registered = false
     @logger = @options.delete(:logger) || Logger.new(STDOUT)
     @log_level = @options.delete(:log_level) || :debug
+    @loop_delay = @options.delete(:loop_delay) || DEFAULT_LOOP_DELAY
 
     register! unless options.delete(:register) == false
   end
@@ -336,7 +341,7 @@ class Poseidon::ConsumerGroup
   #
   # @api public
   def fetch_loop(opts = {})
-    delay = opts[:loop_delay] || options[:loop_delay] || DEFAULT_LOOP_DELAY
+    delay = opts[:loop_delay] || @loop_delay
 
     loop do
       mp = false

--- a/lib/poseidon/consumer_group.rb
+++ b/lib/poseidon/consumer_group.rb
@@ -39,7 +39,11 @@ class Poseidon::ConsumerGroup
       offset = group.offset(partition)
       # if trail is set to true, it should always use latest offset. Otherwise use the zookeeper offset
       # if there was one, or earliset available if there wasn't.
-      offset = (options[:trail] ? :latest_offset : (offset == 0 ? :earliest_offset : offset))
+      if options[:trail]
+        offset = :latest_offset
+      else
+        offset = :earliest_offset if offset == 0
+      end
       options.delete(:trail)
       super group.id, broker.host, broker.port, group.topic, partition, offset, options
     end
@@ -100,7 +104,6 @@ class Poseidon::ConsumerGroup
   #
   # @api public
   def initialize(name, brokers, zookeepers, topic, options = {})
-    puts options.inspect
     @name       = name
     @topic      = topic
     @zk         = ::ZK.new(zookeepers.join(","))

--- a/spec/lib/poseidon/consumer_group_spec.rb
+++ b/spec/lib/poseidon/consumer_group_spec.rb
@@ -154,6 +154,11 @@ describe Poseidon::ConsumerGroup do
       trailing_consumer.offset.should == :latest_offset
     end
 
+    it 'should start with the latest offset if in trailing mode even if offset was stored' do
+      trailing_consumer = described_class::Consumer.new group, 1, {trail: true}
+      trailing_consumer.offset.should == :latest_offset
+    end
+
   end
 
   describe "rebalance!" do

--- a/spec/lib/poseidon/consumer_group_spec.rb
+++ b/spec/lib/poseidon/consumer_group_spec.rb
@@ -138,12 +138,12 @@ describe Poseidon::ConsumerGroup do
 
   it "should accept a loop_delay" do
     cg = described_class.new "my-group", ["localhost:29092", "localhost:29091"], ["localhost:22181"], "mytopic", logger: logger, loop_delay: 5
-    cg.loop_delay == 5
+    cg.loop_delay.should == 5
   end
 
   it "should accept a loop_delay under 1sec" do
     cg = described_class.new "my-group", ["localhost:29092", "localhost:29091"], ["localhost:22181"], "mytopic", logger: logger, loop_delay: 0.1
-    cg.loop_delay == 0.1
+    cg.loop_delay.should == 0.1
   end
 
   describe "consumer" do

--- a/spec/lib/poseidon/consumer_group_spec.rb
+++ b/spec/lib/poseidon/consumer_group_spec.rb
@@ -136,6 +136,16 @@ describe Poseidon::ConsumerGroup do
     n.should == 400
   end
 
+  it "should accept a loop_delay" do
+    cg = described_class.new "my-group", ["localhost:29092", "localhost:29091"], ["localhost:22181"], "mytopic", logger: logger, loop_delay: 5
+    cg.loop_delay == 5
+  end
+
+  it "should accept a loop_delay under 1sec" do
+    cg = described_class.new "my-group", ["localhost:29092", "localhost:29091"], ["localhost:22181"], "mytopic", logger: logger, loop_delay: 0.1
+    cg.loop_delay == 0.1
+  end
+
   describe "consumer" do
     subject { described_class::Consumer.new group, 1 }
     before  { group.stub(:offset).with(1).and_return(432) }


### PR DESCRIPTION
These two changes will allow for some improved testing reliability and speed in our rspec tests.
1) allow trail option to overwrite the zookeeper stored offset. There should be a way to start from latest, even if an offset is stored.
2) There was a bug that prevented the setting of the fetch_loop option. This allows for that to be set properly, which will allow us to tighten up that loop and speed up our tests.

One thing that I'm not sure about. Once this is merged in, how do we use this properly in our tests? I'm a little unfamiliar with the ruby gem / dependency stuff.